### PR TITLE
fix: botReady.js in twitch-notifications

### DIFF
--- a/modules/twitch-notifications/events/botReady.js
+++ b/modules/twitch-notifications/events/botReady.js
@@ -80,7 +80,7 @@ function twitchNotifications(client, apiClient) {
     }
 }
 
-exports.run = async (client) => {
+module.exports.run = async (client) => {
     const config = client.configurations['twitch-notifications']['config'];
 
     const ClientID = config['twitchClientID'];


### PR DESCRIPTION
fix: why does that worked?